### PR TITLE
Fixed extraStats calculation

### DIFF
--- a/db/models/hero.ts
+++ b/db/models/hero.ts
@@ -238,7 +238,7 @@ export default class HeroModel extends DatabaseInterface<Hero> {
         );
 
       // make sure we have 7 stats to spend
-      if (extraStats > 7) {
+      if (extraStats >= 7) {
         const removableStats = stats
           .filter(
             (statName) =>


### PR DESCRIPTION
Changed > 7 to >= 7 to fix a bug where leveling up with exactly 7 stat points extra would fail: https://discordapp.com/channels/946157918603063368/946158193329991723/955857082400268318